### PR TITLE
Matching pyqtorch version with qadence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "rich",
     "tensorboard>=2.12.0",
     "nevergrad",
-    "pyqtorch==1.7.3",
+    "pyqtorch==1.7.5",
     "pyyaml",
     "matplotlib",
 ]


### PR DESCRIPTION
Qadence and Perceptrain are using different version of PyQTorch.
Qadence uses pyqtorch version 1.7.5 while perceptrain is using 1.7.3.
This causes dependency error on qadence-hub when using both packages.

Thus updating perceptrain pyqtorch version to 1.7.5. It passes all the tests and docs building.
Probably best to have automation for future releases.