### PR TITLE
Removing pyq version in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "rich",
     "tensorboard>=2.12.0",
     "nevergrad",
-    "pyqtorch==1.7.5",
+    "pyqtorch",
     "pyyaml",
     "matplotlib",
 ]


### PR DESCRIPTION
I removed pyq version in pyproject.toml as it conflicts with pyq version qadence and cannot use both in qadence-model.
However, I recall that I added the pyq version for the other reason which I cannot remember now.
I'll test with this PR and release. And if the conflict still happens, I'll make the renovate bot to handle this.